### PR TITLE
🧪 Add tests for config module and expand prompt/cli test coverage

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,23 @@
+from pathlib import Path
+
+import git
 import pytest
 
-from vibes import __version__
-from vibes.cli import app
+pydantic_ai_importable = True
+try:
+    from pydantic_ai import Agent  # noqa: F401
+except TypeError:
+    # pydantic_ai fails to import on Python 3.14 RC due to upstream pydantic bug
+    pydantic_ai_importable = False
+
+pytestmark = pytest.mark.skipif(
+    not pydantic_ai_importable,
+    reason="pydantic_ai cannot be imported (pydantic incompatibility with this Python)",
+)
+
+if pydantic_ai_importable:
+    from vibes import __version__
+    from vibes.cli import app
 
 
 def test_version(
@@ -11,3 +27,53 @@ def test_version(
         app("--version")
     assert exc_info.value.code == 0
     assert capsys.readouterr().out.strip() == __version__
+
+
+def test_only_prompt_prints_prompt_and_exits(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--only-prompt should print the prompt to stdout and return 0."""
+    repo = git.Repo.init(tmp_path)
+    (tmp_path / "file.txt").write_text("hello\n")
+    repo.index.add(["file.txt"])
+    repo.index.commit("init")
+    (tmp_path / "file.txt").write_text("hello world\n")
+    repo.index.add(["file.txt"])
+
+    ret = app("--repo", str(tmp_path), "--only-prompt")
+    captured = capsys.readouterr().out
+    assert ret == 0
+    # The prompt should contain the diff
+    assert "hello world" in captured
+    repo.close()
+
+
+def test_invalid_repo_path(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Passing a path that is not a git repo should exit with error."""
+    not_a_repo = tmp_path / "nope"
+    not_a_repo.mkdir()
+    with pytest.raises(SystemExit) as exc_info:
+        app("--repo", str(not_a_repo))
+    assert exc_info.value.code == 1
+    assert "not a valid git repository" in capsys.readouterr().err
+
+
+def test_bad_commit_ref(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Passing an invalid commit reference should exit with error."""
+    repo = git.Repo.init(tmp_path)
+    (tmp_path / "f.txt").write_text("x\n")
+    repo.index.add(["f.txt"])
+    repo.index.commit("init")
+
+    with pytest.raises(SystemExit) as exc_info:
+        app("--repo", str(tmp_path), "-c", "nonexistent_ref_xyz")
+    assert exc_info.value.code == 1
+    assert "Error" in capsys.readouterr().err
+    repo.close()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,9 +41,10 @@ def test_only_prompt_prints_prompt_and_exits(
     (tmp_path / "file.txt").write_text("hello world\n")
     repo.index.add(["file.txt"])
 
-    ret = app("--repo", str(tmp_path), "--only-prompt")
+    with pytest.raises(SystemExit) as exc_info:
+        app(["--repo", str(tmp_path), "--only-prompt"])
+    assert exc_info.value.code == 0
     captured = capsys.readouterr().out
-    assert ret == 0
     # The prompt should contain the diff
     assert "hello world" in captured
     repo.close()
@@ -57,7 +58,7 @@ def test_invalid_repo_path(
     not_a_repo = tmp_path / "nope"
     not_a_repo.mkdir()
     with pytest.raises(SystemExit) as exc_info:
-        app("--repo", str(not_a_repo))
+        app(["--repo", str(not_a_repo)])
     assert exc_info.value.code == 1
     assert "not a valid git repository" in capsys.readouterr().err
 
@@ -73,7 +74,7 @@ def test_bad_commit_ref(
     repo.index.commit("init")
 
     with pytest.raises(SystemExit) as exc_info:
-        app("--repo", str(tmp_path), "-c", "nonexistent_ref_xyz")
+        app(["--repo", str(tmp_path), "-c", "nonexistent_ref_xyz"])
     assert exc_info.value.code == 1
     assert "Error" in capsys.readouterr().err
     repo.close()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,21 +3,8 @@ from pathlib import Path
 import git
 import pytest
 
-pydantic_ai_importable = True
-try:
-    from pydantic_ai import Agent  # noqa: F401
-except TypeError:
-    # pydantic_ai fails to import on Python 3.14 RC due to upstream pydantic bug
-    pydantic_ai_importable = False
-
-pytestmark = pytest.mark.skipif(
-    not pydantic_ai_importable,
-    reason="pydantic_ai cannot be imported (pydantic incompatibility with this Python)",
-)
-
-if pydantic_ai_importable:
-    from vibes import __version__
-    from vibes.cli import app
+from vibes import __version__
+from vibes.cli import app
 
 
 def test_version(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -80,38 +80,37 @@ class TestGetApiKey:
 provider = "anthropic"
 
 [providers.anthropic]
-api_key = "sk-from-file"
+api_key = "test-key-from-file"  # pragma: allowlist secret
 """
         with _config_env(tmp_path, toml) as cfg:
-            assert cfg.get_api_key() == "sk-from-file"
+            assert cfg.get_api_key() == "test-key-from-file"
 
     def test_from_env_var(self, tmp_path: Path) -> None:
         with _config_env(
             tmp_path,
             'provider = "openai"\n',
-            env={"OPENAI_API_KEY": "sk-from-env"},
+            env={"OPENAI_API_KEY": "test-key-from-env"},  # pragma: allowlist secret
         ) as cfg:
-            assert cfg.get_api_key() == "sk-from-env"
+            assert cfg.get_api_key() == "test-key-from-env"
 
     def test_explicit_provider_arg(self, tmp_path: Path) -> None:
         with _config_env(
             tmp_path,
             'provider = "anthropic"\n',
-            env={"OPENAI_API_KEY": "sk-openai"},
+            env={"OPENAI_API_KEY": "test-key-openai"},  # pragma: allowlist secret
         ) as cfg:
-            assert cfg.get_api_key("openai") == "sk-openai"
+            assert cfg.get_api_key("openai") == "test-key-openai"
 
     def test_config_file_takes_precedence_over_env(self, tmp_path: Path) -> None:
         toml = """\
 provider = "anthropic"
 
 [providers.anthropic]
-api_key = "sk-from-file"
+api_key = "test-key-from-file"  # pragma: allowlist secret
 """
-        with _config_env(
-            tmp_path, toml, env={"ANTHROPIC_API_KEY": "sk-from-env"}
-        ) as cfg:
-            assert cfg.get_api_key() == "sk-from-file"
+        env = {"ANTHROPIC_API_KEY": "test-key-from-env"}  # pragma: allowlist secret
+        with _config_env(tmp_path, toml, env=env) as cfg:
+            assert cfg.get_api_key() == "test-key-from-file"
 
     def test_missing_raises(self, tmp_path: Path) -> None:
         with (

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,189 @@
+"""Tests for the config module."""
+
+import importlib
+import os
+from collections.abc import Generator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+if TYPE_CHECKING:
+    import vibes.config
+
+
+def _clean_env() -> dict[str, str]:
+    """Return os.environ without any vibes/provider keys."""
+    return {
+        k: v
+        for k, v in os.environ.items()
+        if not k.startswith(("VIBES_", "OPENAI_", "ANTHROPIC_", "GOOGLE_"))
+    }
+
+
+@contextmanager
+def _config_env(
+    tmp_path: Path,
+    config_toml: str = "",
+    env: dict[str, str] | None = None,
+) -> Generator["vibes.config"]:
+    """Context manager that reloads vibes.config with controlled file+env.
+
+    The patched environment stays active for the duration of the block,
+    so function calls inside will see the right env vars.
+    """
+    config_file = tmp_path / "config.toml"
+    if config_toml:
+        config_file.write_text(config_toml)
+
+    merged_env = _clean_env()
+    if env:
+        merged_env.update(env)
+
+    with (
+        patch("platformdirs.user_config_dir", return_value=str(tmp_path)),
+        patch.dict(os.environ, merged_env, clear=True),
+    ):
+        import vibes.config  # noqa: PLC0415
+
+        importlib.reload(vibes.config)
+        yield vibes.config
+
+
+class TestGetProvider:
+    def test_from_config_file(self, tmp_path: Path) -> None:
+        with _config_env(tmp_path, 'provider = "anthropic"\n') as cfg:
+            assert cfg.get_provider() == "anthropic"
+
+    def test_from_env_var(self, tmp_path: Path) -> None:
+        with _config_env(tmp_path, env={"VIBES_PROVIDER": "openai"}) as cfg:
+            assert cfg.get_provider() == "openai"
+
+    def test_config_file_takes_precedence_over_env(self, tmp_path: Path) -> None:
+        with _config_env(
+            tmp_path,
+            'provider = "anthropic"\n',
+            env={"VIBES_PROVIDER": "openai"},
+        ) as cfg:
+            assert cfg.get_provider() == "anthropic"
+
+    def test_missing_raises(self, tmp_path: Path) -> None:
+        with (
+            _config_env(tmp_path) as cfg,
+            pytest.raises(ValueError, match="No provider configured"),
+        ):
+            cfg.get_provider()
+
+
+class TestGetApiKey:
+    def test_from_config_file(self, tmp_path: Path) -> None:
+        toml = """\
+provider = "anthropic"
+
+[providers.anthropic]
+api_key = "sk-from-file"
+"""
+        with _config_env(tmp_path, toml) as cfg:
+            assert cfg.get_api_key() == "sk-from-file"
+
+    def test_from_env_var(self, tmp_path: Path) -> None:
+        with _config_env(
+            tmp_path,
+            'provider = "openai"\n',
+            env={"OPENAI_API_KEY": "sk-from-env"},
+        ) as cfg:
+            assert cfg.get_api_key() == "sk-from-env"
+
+    def test_explicit_provider_arg(self, tmp_path: Path) -> None:
+        with _config_env(
+            tmp_path,
+            'provider = "anthropic"\n',
+            env={"OPENAI_API_KEY": "sk-openai"},
+        ) as cfg:
+            assert cfg.get_api_key("openai") == "sk-openai"
+
+    def test_config_file_takes_precedence_over_env(self, tmp_path: Path) -> None:
+        toml = """\
+provider = "anthropic"
+
+[providers.anthropic]
+api_key = "sk-from-file"
+"""
+        with _config_env(
+            tmp_path, toml, env={"ANTHROPIC_API_KEY": "sk-from-env"}
+        ) as cfg:
+            assert cfg.get_api_key() == "sk-from-file"
+
+    def test_missing_raises(self, tmp_path: Path) -> None:
+        with (
+            _config_env(tmp_path, 'provider = "anthropic"\n') as cfg,
+            pytest.raises(ValueError, match="No API key found"),
+        ):
+            cfg.get_api_key()
+
+
+class TestGetModel:
+    def test_from_config_file(self, tmp_path: Path) -> None:
+        toml = """\
+provider = "anthropic"
+
+[providers.anthropic]
+model = "claude-opus-4"
+"""
+        with _config_env(tmp_path, toml) as cfg:
+            assert cfg.get_model() == "claude-opus-4"
+
+    def test_from_env_var(self, tmp_path: Path) -> None:
+        with _config_env(
+            tmp_path,
+            'provider = "openai"\n',
+            env={"OPENAI_MODEL": "gpt-4o"},
+        ) as cfg:
+            assert cfg.get_model() == "gpt-4o"
+
+    def test_defaults(self, tmp_path: Path) -> None:
+        with _config_env(tmp_path, 'provider = "openai"\n') as cfg:
+            assert cfg.get_model() == "gpt-5"
+
+        with _config_env(tmp_path, 'provider = "anthropic"\n') as cfg:
+            assert cfg.get_model() == "claude-sonnet-4-5"
+
+        with _config_env(tmp_path, 'provider = "google"\n') as cfg:
+            assert cfg.get_model() == "gemini-3-pro"
+
+    def test_config_file_takes_precedence_over_env_and_defaults(
+        self, tmp_path: Path
+    ) -> None:
+        toml = """\
+provider = "openai"
+
+[providers.openai]
+model = "gpt-4o"
+"""
+        with _config_env(tmp_path, toml, env={"OPENAI_MODEL": "gpt-3.5-turbo"}) as cfg:
+            assert cfg.get_model() == "gpt-4o"
+
+    def test_env_takes_precedence_over_defaults(self, tmp_path: Path) -> None:
+        with _config_env(
+            tmp_path,
+            'provider = "openai"\n',
+            env={"OPENAI_MODEL": "gpt-4o"},
+        ) as cfg:
+            assert cfg.get_model() == "gpt-4o"
+
+    def test_explicit_provider_arg(self, tmp_path: Path) -> None:
+        with _config_env(
+            tmp_path,
+            'provider = "anthropic"\n',
+            env={"OPENAI_MODEL": "gpt-4o"},
+        ) as cfg:
+            assert cfg.get_model("openai") == "gpt-4o"
+
+    def test_unknown_provider_no_model_raises(self, tmp_path: Path) -> None:
+        with (
+            _config_env(tmp_path, 'provider = "custom"\n') as cfg,
+            pytest.raises(ValueError, match="No model found"),
+        ):
+            cfg.get_model()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,13 +5,10 @@ import os
 from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING
+from types import ModuleType
 from unittest.mock import patch
 
 import pytest
-
-if TYPE_CHECKING:
-    import vibes.config
 
 
 def _clean_env() -> dict[str, str]:
@@ -28,7 +25,7 @@ def _config_env(
     tmp_path: Path,
     config_toml: str = "",
     env: dict[str, str] | None = None,
-) -> Generator["vibes.config"]:
+) -> Generator[ModuleType]:
     """Context manager that reloads vibes.config with controlled file+env.
 
     The patched environment stays active for the duration of the block,

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -198,6 +198,34 @@ def test_get_repo_info_handle_readme_not_found(git_repo: GitRepo) -> None:
     assert result == expected_result
 
 
+def test_get_repo_info_at_sign_resolves_to_head(git_repo: GitRepo) -> None:
+    """Test that @ in commit range is replaced with HEAD."""
+    result_at = get_repo_info(git_repo.repo, "@~1..@")
+    result_head = get_repo_info(git_repo.repo, "HEAD~1..HEAD")
+    assert result_at == result_head
+
+
+def test_get_repo_info_filters_test_files(git_repo: GitRepo) -> None:
+    """Test that files under tests/ are excluded from ls-files."""
+    test_file = git_repo.path / "tests" / "test_something.py"
+    test_file.parent.mkdir()
+    test_file.write_text("assert True\n")
+    git_repo.repo.index.add([str(test_file)])
+    git_repo.repo.index.commit(message="commit #4, add test file")
+
+    result = get_repo_info(git_repo.repo, "HEAD")
+    assert "tests/test_something.py" not in result["git_ls_files"]
+    # Non-test files still present
+    assert "sample_file" in result["git_ls_files"]
+
+
+def test_get_repo_info_no_diff_falls_back_to_head(git_repo: GitRepo) -> None:
+    """When staging and working tree are clean, falls back to HEAD commit."""
+    result_empty = get_repo_info(git_repo.repo, "")
+    result_head = get_repo_info(git_repo.repo, "HEAD")
+    assert result_empty == result_head
+
+
 def test_get_prompt(git_repo: GitRepo) -> None:
     """Test get_prompt assembles the prompt correctly."""
     description = "Test description"
@@ -240,3 +268,10 @@ Test description
 ```
 """)
     assert expected_prompt_end in prompt
+
+
+def test_get_prompt_strips_description_whitespace(git_repo: GitRepo) -> None:
+    """Test get_prompt strips whitespace from description."""
+    prompt = get_prompt(git_repo.repo, "HEAD", "  padded  ")
+    assert "padded" in prompt
+    assert "  padded  " not in prompt


### PR DESCRIPTION
## Summary

- **test_config.py** (16 tests): full coverage for `get_provider`, `get_api_key`, `get_model` — file config, env vars, precedence rules, and error cases. config.py: 0% → 100%
- **test_prompt.py** (+4 tests): `@` alias resolution, test file filtering from ls-files, no-diff fallback to HEAD, description whitespace stripping. prompt.py: 97% → 100%
- **test_cli.py** (+3 tests): `--only-prompt` flag, invalid repo path, bad commit ref. cli.py: 0% → 51%

Remaining uncovered in cli.py (lines 72-101): live AI agent calls and interactive REPL loop — not suitable for unit tests without mocking implementation details.

**Overall coverage: 40% → 83%**

## Test plan

- [x] `just test` — 32 passed on Python 3.13
- [x] `mypy` — no issues
- [x] `ruff check` — all checks passed
- [x] `detect-secrets` — no findings (test keys allowlisted)

https://claude.ai/code/session_01PouQgkLLosw7XbnJujzmed